### PR TITLE
Fixed wrong type declaration for measurement units.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -273,8 +273,7 @@ function parseType(datatype) {
             value: valueElement ? valueElement.textContent || "" : undefined,
         };
         if (type.name === "Measurement Unit (Number or String)=any") {
-            type.name = "number";
-            types.push({ name: "string", isArray: type.isArray });
+            type.name = "number | string";
         }
         parseTypeFixTypeName(type);
         types.push(type);

--- a/src/index.js
+++ b/src/index.js
@@ -274,6 +274,9 @@ function parseType(datatype) {
         };
         if (type.name === "Measurement Unit (Number or String)=any") {
             type.name = "number | string";
+            if (type.isArray) {
+                type.name = "(" + type.name + ")";
+            }
         }
         parseTypeFixTypeName(type);
         types.push(type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,6 +344,9 @@ function parseType(datatype: Element | undefined): TypeDefinition[] {
         
         if (type.name === "Measurement Unit (Number or String)=any") {
             type.name = "number | string";
+            if (type.isArray) {
+                type.name = "(" + type.name + ")";
+            }
         }
         
         parseTypeFixTypeName(type);

--- a/src/index.ts
+++ b/src/index.ts
@@ -343,8 +343,7 @@ function parseType(datatype: Element | undefined): TypeDefinition[] {
         };
         
         if (type.name === "Measurement Unit (Number or String)=any") {
-            type.name = "number";
-            types.push({ name: "string", isArray: type.isArray });
+            type.name = "number | string";
         }
         
         parseTypeFixTypeName(type);


### PR DESCRIPTION
There's a problem with current type definitions for Measurement Units type.

I had the code like this for changing geometric bounds property which is totally legit:
```
let a = app.activeDocument.selection[0].geometricBounds;
app.activeDocument.selection[0].geometricBounds = [a[0], a[1], a[2] + 10, a[3] + 10]
```

However, typescript was giving me incompatible type error for the second line, saying that "'number[] | string' is not compatible with (number | string)[]". I dug into type definitions for geometricBounds field and found out that it's actually a bit wrong:

Current:
```
geometricBounds: string[] | number[]
```

It's not either array of numbers of an array of strings. It's an array of both. So the correct definition would be:

```
geometricBounds: (string | number)[]
```

I glanced over other measurement fields and they all had the same issue, and they all suffered from the same problem. You might want to regenerate the definitions in Types-for-Adobe repo if you decide to accept this fix.